### PR TITLE
fix: asyncData to fetch

### DIFF
--- a/apis/$api.ts
+++ b/apis/$api.ts
@@ -8,9 +8,9 @@ const api = <T>(client: AspidaClient<T>) => {
   return {
     hellosalut: {
       get: (option: { query: Methods0['get']['query'], config?: T }) =>
-        client.fetch<Methods0['get']['resBody']>(prefix, '/hellosalut', 'GET', option).json(),
+        client.fetch<Methods0['get']['resBody']>(prefix, '/hellosalut/', 'GET', option).json(),
       $get: async (option: { query: Methods0['get']['query'], config?: T }) =>
-        (await client.fetch<Methods0['get']['resBody']>(prefix, '/hellosalut', 'GET', option).json()).data
+        (await client.fetch<Methods0['get']['resBody']>(prefix, '/hellosalut/', 'GET', option).json()).data
     }
   }
 }

--- a/aspida.config.js
+++ b/aspida.config.js
@@ -1,0 +1,1 @@
+module.exports = { trailingSlash: true }

--- a/pages/example.vue
+++ b/pages/example.vue
@@ -8,8 +8,8 @@
     </thead>
     <tbody>
       <tr v-for="greeting in greetings" :key="greeting.code">
-        <td>{ greeting.code  }</td>
-        <td>{ greeting.hello }</td>
+        <td>{{ greeting.code }}</td>
+        <td>{{ greeting.hello }}</td>
       </tr>
     </tbody>
   </table>
@@ -26,20 +26,23 @@ export default Vue.extend({
     }
   },
   
-  async asyncData({ app }) {
-    let langs = [ 'en', 'zh', 'de', 'fr', 'ja' ]
+  async fetch() {
+    const langs = [ 'en', 'zh', 'de', 'fr', 'ja' ]
 
-    this.greetings = await Promise.all(langs.map(async lang => {
-      const res = await $nuxt.$api.hellosalut.$get({ query: { lang: 'ja' } })
-      res.hello = res.hello.startsWith('&#')
-                ? String.fromCharCode(
-                    ...res.hello
-                      .slice(2, -1)
-                      .split(';&#')
-                      .map((n) => +n)
-                  )
-                : res.hello
-      return res
+    this.greetings = (
+      await Promise.all(
+        langs.map((lang) => this.$api.hellosalut.$get({ query: { lang } }))
+      )
+    ).map(({ code, hello }) => ({
+      code,
+      hello: hello.startsWith('&#')
+        ? String.fromCharCode(
+            ...hello
+              .slice(2, -1)
+              .split(';&#')
+              .map((n) => +n)
+          )
+        : hello
     }))
   }
 })


### PR DESCRIPTION
- curlで確認したところ、Hello APIはクエリの直前にスラッシュがないとレスされないのでaspida.config.jsにtrailingSlashオプションを追加
  - NG: https://fourtonfish.com/hellosalut?lang=ja
  - OK: https://fourtonfish.com/hellosalut/?lang=ja

- universalモードだと$nuxtがglobalにないらしく、appまたはthisから$apiを呼ぶ

- 型推論が効かないasyncDataの代わりにNuxt2.12で改修されたfetchに変更（asyncDataを使う場合はthisではなくreturnで返す）
  参考：https://qiita.com/miyaoka/items/11fdc03ff591d34a585c

- fetch内において、APIリクエストとレスポンス加工を分離してみた

- コード整形は手元のESLint+Prettierで行った